### PR TITLE
Add UPLOAD_MAX_FILESIZE container environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Markus Mayer <awesome@wundercart.de>
 ENV APP_BASE /var/www
 ENV APP_BRANCH master
 ENV DEBIAN_VERSION jessie
-ENV HHVM_VERSION 3.13.1~$DEBIAN_VERSION
+ENV HHVM_VERSION 3.18.1~$DEBIAN_VERSION
 
 # Install HHVM, Supervisor and PHP DBO connectors
 RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0x5a16e7281be7a449 && \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Note that some NuGet clients might be picky about the port, so be sure to have y
 
 * `NUGET_API_KEY` sets the NuGet feed's API key to your own private key
 * `BASE_URL` sets the base path of the feed, e.g. `/nuget` if it is available under `http://your.tld/nuget/`
+* `UPLOAD_MAX_FILESIZE` (optional) sets the maximum allowed filesize when uploading NuGet packages via API. Default is 20M.
 
 ### Exported volumes
 

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -27,6 +27,18 @@ stderr_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 
+[program:patchfilesize]
+command=/tmp/patch-filesize.sh
+priority=0
+autorestart=false
+startsecs=0
+redirect_stdout=true
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=0
+
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"
 priority=200

--- a/scripts/patch-filesize.sh
+++ b/scripts/patch-filesize.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DEFAULT_SIZE=20M
+
+if [ -z ${UPLOAD_MAX_FILESIZE+false} ]
+then
+    echo "Using default max upload size: ${DEFAULT_SIZE}"
+else
+    echo "Using max upload size: ${UPLOAD_MAX_FILESIZE}"
+    
+    # set size in nginx
+    perl -pi -e "s/client_max_body_size(\s*)${DEFAULT_SIZE};/client_max_body_size\${1}${UPLOAD_MAX_FILESIZE};/" /etc/nginx/conf.d/nuget.conf
+    
+    # set size in php.ini
+    perl -pi -e "s/upload_max_filesize = ${DEFAULT_SIZE}/upload_max_filesize = ${UPLOAD_MAX_FILESIZE}/" /etc/hhvm/php.ini
+    perl -pi -e "s/post_max_size = ${DEFAULT_SIZE}/post_max_filesize = ${UPLOAD_MAX_FILESIZE}/" /etc/hhvm/php.ini
+fi


### PR DESCRIPTION
Adds a method for increasing the maximum allowed file size of a .nupkg

